### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 .PHONY: init
 init:
 	@cargo install --locked cargo-pgrx@0.11.4
-	@if ! cargo pgrx info version pg$(PG_VERSION) >/dev/null 2>1; then cargo pgrx init --pg$(PG_VERSION) download; else echo "pg$(PG_VERSION) already installed"; fi
+	@if ! cargo pgrx info version pg$(PG_VERSION) >/dev/null 2>&1; then cargo pgrx init --pg$(PG_VERSION) download; else echo "pg$(PG_VERSION) already installed"; fi
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
`make init` was accidentally creating a local file called `1` :man_facepalming: 